### PR TITLE
Added http:// protocol to CORS_ORIGIN_WHITELIST

### DIFF
--- a/tips/settings.py
+++ b/tips/settings.py
@@ -138,5 +138,5 @@ STATIC_URL = '/static/'
 STATIC_ROOT = os.path.join(BASE_DIR, 'static/')
 
 CORS_ORIGIN_WHITELIST = (
-    'localhost:3000',
+    'http://localhost:3000',
 )


### PR DESCRIPTION
Received error:
```
?: (corsheaders.E013) Origin 'localhost:3000' in CORS_ORIGIN_WHITELIST is missing  scheme or netloc
	HINT: Add a scheme (e.g. https://) or netloc (e.g. example.com).
```